### PR TITLE
Add Jenkinsfile for Continuous Integration Setup

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]  # Trigger the build on every push or pull request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Use a Linux environment for the build
+    steps:
+    - uses: actions/checkout@v2  # Check out the code from your repository
+    
+    - name: Set up JDK 11  # Set up Java Development Kit (JDK) version 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: '11'
+
+    - name: Build with Gradle  # Run the Gradle build process
+      run: ./gradlew build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/Jenskinsfile
+++ b/Jenskinsfile
@@ -1,0 +1,23 @@
+pipeline {
+    agent any  // This tells Jenkins to use any available agent to run the pipeline
+
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew assemble'  // Run the Gradle build task to assemble the project
+            }
+        }
+        stage('Test') {
+            steps {
+                sh './gradlew test'  // Run the Gradle test task to execute unit tests
+            }
+        }
+    }
+
+    post {
+        always {
+            junit '**/build/test-results/test/*.xml'  // Collect and publish test results in JUnit format
+            archiveArtifacts artifacts: '**/build/libs/*.jar', allowEmptyArchive: true  // Archive the build artifacts (e.g., JAR files)
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a Jenkinsfile to set up Continuous Integration for the mock-company-webapp repository. The Jenkinsfile includes two main stages: Build and Test.

- **Build Stage**: Executes the Gradle build task using `./gradlew assemble` to compile the application.
- **Test Stage**: Runs unit tests using `./gradlew test` to ensure code quality and correctness.

Additionally, the post-processing steps include:
- Collecting test results in JUnit format for easy reporting.
- Archiving build artifacts (JAR files) to allow for further deployment or inspection.

This CI setup will help maintain code quality by automatically running builds and tests on each commit. 

To demonstrate the CI setup, I modified the `SearchService` class to return `Collections.emptyList()` to simulate a failing test case. This change has been validated by confirming that the CI pipeline fails as expected.

Please review the changes and let me know if there are any questions or further adjustments needed.
